### PR TITLE
feat: enable skill after deploy resources finished

### DIFF
--- a/lib/commands/deploy/helper.js
+++ b/lib/commands/deploy/helper.js
@@ -2,11 +2,13 @@ const SkillMetadataController = require('@src/controllers/skill-metadata-control
 const SkillCodeController = require('@src/controllers/skill-code-controller');
 const SkillInfrastructureController = require('@src/controllers/skill-infrastructure-controller');
 const profileHelper = require('@src/utils/profile-helper');
+const Messenger = require('@src/view/messenger');
 
 module.exports = {
     deploySkillMetadata,
     buildSkillCode,
-    deploySkillInfrastructure
+    deploySkillInfrastructure,
+    enableSkill
 };
 
 /**
@@ -59,6 +61,23 @@ function deploySkillInfrastructure(profile, doDebug, callback) {
     skillInfraController.deployInfrastructure((deployError) => {
         if (deployError) {
             return callback(deployError);
+        }
+        callback();
+    });
+}
+
+/**
+ * Funtion used to enable skill
+ * @param {string} profile The profile name
+ * @param {Boolean} doDebug The flag of debug or not
+ * @param {Function} callback
+ */
+function enableSkill(profile, doDebug, callback) {
+    const skillMetaController = new SkillMetadataController({ profile, doDebug });
+    Messenger.getInstance().info('\n==================== Enable Skill ====================');
+    skillMetaController.enableSkill((error) => {
+        if (error) {
+            return callback(error);
         }
         callback();
     });

--- a/lib/commands/deploy/index.js
+++ b/lib/commands/deploy/index.js
@@ -1,8 +1,8 @@
 const path = require('path');
 
 const { AbstractCommand } = require('@src/commands/abstract-command');
-const Manifest = require('@src/model/manifest');
 const ResourcesConfig = require('@src/model/resources-config');
+const Manifest = require('@src/model/manifest');
 const Messenger = require('@src/view/messenger');
 const SpinnerView = require('@src/view/spinner-view');
 const optionModel = require('@src/commands/option-model');
@@ -55,7 +55,16 @@ class DeployCommand extends AbstractCommand {
 
             ResourcesConfig.getInstance().write();
             Manifest.getInstance().write();
-            cb();
+
+            // Post deploy logic
+            // call smapiClient to enable skill
+            helper.enableSkill(profile, cmd.debug, (enableError) => {
+                if (enableError) {
+                    Messenger.getInstance().error(enableError);
+                    return cb(enableError);
+                }
+                cb();
+            });
         });
     }
 }

--- a/lib/controllers/skill-metadata-controller/index.js
+++ b/lib/controllers/skill-metadata-controller/index.js
@@ -1,10 +1,13 @@
 const fs = require('fs-extra');
 const path = require('path');
+const R = require('ramda');
 
 const retryUtils = require('@src/utils/retry-utility');
 const ResourcesConfig = require('@src/model/resources-config');
 const SmapiClient = require('@src/clients/smapi-client/index.js');
 const httpClient = require('@src/clients/http-client');
+const Manifest = require('@src/model/manifest');
+const Messenger = require('@src/view/messenger');
 const jsonView = require('@src/view/json-view');
 const stringUtils = require('@src/utils/string-utils');
 const zipUtils = require('@src/utils/zip-utils');
@@ -59,6 +62,55 @@ module.exports = class SkillMetadataController {
                 ResourcesConfig.getInstance().setSkillMetaLastDeployHash(this.profile, currentHash);
                 callback();
             });
+        });
+    }
+
+    /**
+     * Function used to enable skill. It calls smapi getSkillEnablement function first to check if skill is already enabled,
+     * if not, it will enable the skill by calling smapi enableSkill function.
+     * @param {Function} callback (err, null)
+     */
+    enableSkill(callback) {
+        const skillId = ResourcesConfig.getInstance().getSkillId(this.profile);
+        const domainInfo = Manifest.getInstance().getApis();
+        if (!stringUtils.isNonBlankString(skillId)) {
+            return callback(`[Fatal]: Failed to find the skillId for profile [${this.profile}],
+ please make sure the skill metadata deployment has succeeded with result of a valid skillId.`);
+        }
+        if (!domainInfo || R.isEmpty(domainInfo)) {
+            return callback('[Error]: Skill information is not valid. Please make sure "apis" field in the skill.json is not empty.');
+        }
+
+        const domainList = R.keys(domainInfo);
+        if (domainList.length !== 1) {
+            return callback('[Warn]: Skill with multiple api domains cannot be enabled. Skip the enable process.');
+        }
+        if (CONSTANTS.SKILL.DOMAIN.CAN_ENABLE_DOMAIN_LIST.indexOf(domainList[0]) === -1) {
+            return callback(`[Warn]: Skill api domain "${domainList[0]}" cannot be enabled. Skip the enable process.`);
+        }
+
+        this.smapiClient.skill.getSkillEnablement(skillId, CONSTANTS.SKILL.STAGE.DEVELOPMENT, (err, response) => {
+            if (err) {
+                return callback(err);
+            }
+            if (response.statusCode === CONSTANTS.HTTP_REQUEST.STATUS_CODE.NOT_FOUND) {
+                this.smapiClient.skill.enableSkill(skillId, CONSTANTS.SKILL.STAGE.DEVELOPMENT, (enableErr, enableResponse) => {
+                    if (enableErr) {
+                        return callback(enableErr);
+                    }
+                    if (enableResponse.statusCode >= 300) {
+                        return callback(jsonView.toString(enableResponse.body));
+                    }
+                    Messenger.getInstance().info('Skill is enabled successfully.');
+
+                    callback();
+                });
+            } else if (response.statusCode >= 300) {
+                callback(jsonView.toString(response.body));
+            } else {
+                Messenger.getInstance().info('Skill is already enabled, skip the enable process.');
+                callback();
+            }
         });
     }
 

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -22,6 +22,9 @@ module.exports.SKILL = {
         SUCCESS: 'SUCCESSFUL',
         FAILURE: 'FAILED',
         IN_PROGRESS: 'IN_PROGRESS'
+    },
+    DOMAIN: {
+        CAN_ENABLE_DOMAIN_LIST: ['custom', 'music']
     }
 };
 

--- a/test/unit/commands/deploy/helper-test.js
+++ b/test/unit/commands/deploy/helper-test.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
+const Messenger = require('@src/view/messenger');
 
 const helper = require('@src/commands/deploy/helper');
 const SkillMetadataController = require('@src/controllers/skill-metadata-controller');
@@ -108,6 +109,44 @@ describe('Commands deploy test - helper test', () => {
                 // verify
                 expect(err).equal(undefined);
                 expect(res).equal(undefined);
+                done();
+            });
+        });
+    });
+
+    describe('# test helper method - enableSkill', () => {
+        let infoStub;
+        beforeEach(() => {
+            infoStub = sinon.stub();
+            sinon.stub(Messenger, 'getInstance').returns({
+                info: infoStub,
+            });
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('| skillMetaController enableSkill fails, expect callback error', (done) => {
+            // setup
+            sinon.stub(SkillMetadataController.prototype, 'enableSkill').callsArgWith(0, 'error');
+            // call
+            helper.enableSkill(TEST_PROFILE, TEST_DO_DEBUG, (err) => {
+                expect(err).equal('error');
+                expect(infoStub.args[0][0]).equal('\n==================== Enable Skill ====================');
+                done();
+            });
+        });
+
+        it('| skillMetaController enableSkill passes, expect no error callback', (done) => {
+            // setup
+            sinon.stub(SkillMetadataController.prototype, 'enableSkill').callsArgWith(0);
+            // call
+            helper.enableSkill(TEST_PROFILE, TEST_DO_DEBUG, (err, res) => {
+                // verify
+                expect(err).equal(undefined);
+                expect(res).equal(undefined);
+                expect(infoStub.args[0][0]).equal('\n==================== Enable Skill ====================');
                 done();
             });
         });


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
Add enable skill logic to ask deploy, when deploying resources finished, cli will call smapi to enable skill

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
