### PR TITLE
chore: enforce conventional commit by introducing commitlint and standard-version

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,30 @@
+{
+  "rules": {
+    "body-leading-blank": [1, "always"],
+    "footer-leading-blank": [1, "always"],
+    "subject-empty": [2, "never"],
+    "subject-case": [
+      2,
+      "always",
+      ["sentence-case", "lower-case", "pascal-case", "camel-case"]
+    ],
+    "scope-case": [2, "always", "lower-case"],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "type-enum": [
+      2,
+      "always",
+      [
+        "chore",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test"
+      ]
+    ]
+  }
+}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,0 @@
-## Aug 26, 2019
-v0.1.0
-- Initial release for ask-cli-x. 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
     <a href="https://www.npmjs.com/package/ask-cli-x"><img src="https://badge.fury.io/js/ask-cli-x.svg"></a>
     <a href="https://travis-ci.org/alexa-labs/ask-cli"><img src="https://travis-ci.org/alexa-labs/ask-cli.svg?branch=master"></a>
   </p>
+  <p align="center">
+    <a href="https://conventionalcommits.org"><img src="https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg"></a>
+  </p>
 </p>
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-cli-x",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Alexa Skills Kit (ASK) Command Line Interfaces - the X version",
   "bin": {
     "askx": "bin/askx.js"
@@ -29,7 +29,8 @@
     "test:report": "nyc --cache npm test && nyc report --reporter=html",
     "test:browser": "npm run test:report && open coverage/index.html",
     "functional-test": "node ./node_modules/mocha/bin/_mocha test/functional/**/*-test.js",
-    "lint": "eslint lib/builtins lib/clients lib/commands lib/controllers lib/model lib/view"
+    "lint": "eslint lib/builtins lib/clients lib/commands lib/controllers lib/model lib/view",
+    "pre-release": "standard-version"
   },
   "dependencies": {
     "archiver": "^1.1.0",
@@ -62,16 +63,26 @@
     "valid-url": "^1.0.9"
   },
   "devDependencies": {
+    "@commitlint/cli": "^8.2.0",
+    "@commitlint/config-conventional": "^8.2.0",
     "chai": "^3.5.0",
     "coveralls": "^3.0.2",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-plugin-import": "^2.18.2",
     "gulp": "^3.9.1",
+    "husky": "^3.0.8",
     "mocha": "^3.2.0",
     "nyc": "^13.3.0",
     "proxyquire": "^1.7.11",
-    "sinon": "^6.0.0"
+    "sinon": "^6.0.0",
+    "standard-version": "^7.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "pre-push": "npm run test:report"
+    }
   },
   "nyc": {
     "check-coverage": true,


### PR DESCRIPTION
Enforce conventional commit by adding commitlint and standard-version to uniform the commit messages and the release flow.

Future flow of releasing will be 

1. **git commit**. Triggers the husky hook "commit-msg", which will check if commit messages comply the conventional commit rules. 
2. **npm run pre-release**. This will commit changelog changes and bump the version.
3. **git push --follow-tags origin master && npm publish**. Triggers husky hook "pre-push", which will make sure to run tests before push, release tags and publish to NPM.

***Note:*** This change also removes the changelog file and revert the version bump, as the release didn't happen. We will be using standard-version to manage the pre-release work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
