### PR TITLE
fix: change from fatal to warn message

### DIFF
--- a/bin/askx-smapi.js
+++ b/bin/askx-smapi.js
@@ -16,7 +16,7 @@ if (!process.argv.slice(2).length) {
             Messenger.getInstance().info(message);
         })
         .catch(err => {
-            Messenger.getInstance().fatal(err.message);
+            Messenger.getInstance().warn(err.message);
             process.exit(1);
         });
 }

--- a/bin/askx-smapi.js
+++ b/bin/askx-smapi.js
@@ -16,7 +16,7 @@ if (!process.argv.slice(2).length) {
             Messenger.getInstance().info(message);
         })
         .catch(err => {
-            Messenger.getInstance().warn(err.message);
+            Messenger.getInstance().error(err.message);
             process.exit(1);
         });
 }


### PR DESCRIPTION
New message should look like 
[Warn]: Blabla

instead of

[Fatal]: Blabla

Test

askx smapi get-skill-status -s xxx
