### PR TITLE
fix: adding -p shortcut and description for default options

### DIFF
--- a/lib/commands/smapi/smapi-commander.js
+++ b/lib/commands/smapi/smapi-commander.js
@@ -7,7 +7,14 @@ const aliases = require('@src/commands/smapi/customizations/aliases.json');
 const { apiToCommanderMap } = require('@src/commands/smapi/customizations/parameters-map');
 
 
-const defaultOptions = ['profile', 'debug'];
+const defaultOptions = [{
+    flags: '-p, --profile <profile>',
+    description: "The ASK CLI profile to use. When you don't include this option, ASK CLI uses the default profile."
+},
+{
+    flags: '--debug',
+    description: 'When you include this option, ASK CLI shows debug messages in the output of the command.'
+}];
 const requiredTemplate = { true: '[REQUIRED]', false: '[OPTIONAL]' };
 const jsonTemplate = { true: '[JSON]\n', false: '' };
 
@@ -65,8 +72,8 @@ const makeSmapiCommander = () => {
             }
         });
 
-        defaultOptions.forEach(optionName => {
-            commanderInstance.option(`--${optionName} <${optionName}>`, '');
+        defaultOptions.forEach(option => {
+            commanderInstance.option(option.flags, option.description);
         });
         commanderInstance.action((inputCmdObj) => smapiCommandHandler(
             apiOperationName,


### PR DESCRIPTION
Adding -p shortcut to --profile flag
Adding description for debug and profile flags.
Description came from https://developer.amazon.com/en-US/docs/alexa/smapi/ask-cli-command-reference.html