### PR TITLE
fix: update to "open" package and add warn messaging for token security

### DIFF
--- a/lib/commands/configure/aws-profile-setup-helper.js
+++ b/lib/commands/configure/aws-profile-setup-helper.js
@@ -1,6 +1,6 @@
 const awsProfileHandler = require('aws-profile-handler');
 const fs = require('fs-extra');
-const opn = require('opn');
+const open = require('open');
 const os = require('os');
 const path = require('path');
 const querystring = require('querystring');
@@ -181,9 +181,9 @@ function _openIamCreateUserPage(isBrowser, userName, callback) {
     Messenger.getInstance().info(messages.AWS_CREATE_PROFILE_TITLE);
     if (isBrowser) {
         setTimeout(() => {
-            opn(awsIamUrl);
+            open(awsIamUrl);
             callback();
-        }, CONSTANTS.CONFIGURATION.OPN_BROWSER_DELAY);
+        }, CONSTANTS.CONFIGURATION.OPEN_BROWSER_DELAY);
     } else {
         Messenger.getInstance().info(messages.AWS_CREATE_PROFILE_NO_BROWSER_OPEN_BROWSER);
         Messenger.getInstance().info(`    ${awsIamUrl}`);

--- a/lib/commands/configure/helper.js
+++ b/lib/commands/configure/helper.js
@@ -16,6 +16,7 @@ module.exports = {
  * @param {Function} callback
  */
 function initiateAskProfileSetup(config, callback) {
+    Messenger.getInstance().warn(messages.LWA_TOKEN_SHARE_WARN_MESSAGE);
     askProfileSetupHelper.setupAskToken(config, (accessTokenError, accessToken) => {
         if (accessTokenError) {
             return callback(accessTokenError);
@@ -34,6 +35,7 @@ function initiateAskProfileSetup(config, callback) {
             AppConfig.getInstance().write();
 
             Messenger.getInstance().info(messages.AWS_CONFIGURATION_MESSAGE);
+            Messenger.getInstance().warn(messages.AWS_SECRET_ACCESS_KEY_AND_ID_SHARE_WARN_MESSAGE);
             awsProfileSetupHelper.setupAwsProfile(config, (awsProfileError, awsProfile) => {
                 if (awsProfileError) {
                     return callback(awsProfileError);

--- a/lib/commands/configure/messages.js
+++ b/lib/commands/configure/messages.js
@@ -24,3 +24,7 @@ module.exports.ACCESS_SECRET_KEY_AND_ID_SETUP = '\nPlease fill in the "Access Ke
 
 module.exports.SKIP_AWS_CONFIGURATION = `------------------------- Skipping the AWS profile association -------------------------
 You will only be able to deploy your Alexa skill. To set up AWS credentials later, use the "ask configure" command towards the same profile again.`;
+
+module.exports.LWA_TOKEN_SHARE_WARN_MESSAGE = 'ASK CLI uses authorization code to fetch LWA tokens. Do not share neither your authorization code nor access tokens.';
+
+module.exports.AWS_SECRET_ACCESS_KEY_AND_ID_SHARE_WARN_MESSAGE = 'ASK CLI will create an IAM user and generate corresponding access key id and secret access key. Do not share neither of them.';

--- a/lib/commands/v2new/hosted-skill-helper.js
+++ b/lib/commands/v2new/hosted-skill-helper.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const opn = require('opn');
+const open = require('open');
 const path = require('path');
 const portScanner = require('portscanner');
 const { URL, URLSearchParams } = require('url');
@@ -189,7 +189,7 @@ function _openLoginUrlWithRedirectLink(captchaUrl, vendorId) {
         ['openid.return_to', `${captchaUrl}?vendor_id=${vendorId}&redirect_url=http://127.0.0.1:9090/captcha`],
         ['openid.pape.max_auth_age', 7200]
     ]).toString();
-    opn(loginUrl.href);
+    open(loginUrl.href);
 }
 
 /**

--- a/lib/controllers/authorization-controller/index.js
+++ b/lib/controllers/authorization-controller/index.js
@@ -1,4 +1,4 @@
-const opn = require('opn');
+const open = require('open');
 const portscanner = require('portscanner');
 const url = require('url');
 
@@ -108,8 +108,8 @@ module.exports = class AuthorizationController {
             Messenger.getInstance().info(messages.AUTH_MESSAGE);
 
             setTimeout(() => {
-                opn(this.oauthClient.generateAuthorizeUrl());
-            }, CONSTANTS.CONFIGURATION.OPN_BROWSER_DELAY);
+                open(this.oauthClient.generateAuthorizeUrl());
+            }, CONSTANTS.CONFIGURATION.OPEN_BROWSER_DELAY);
 
             this._listenResponseFromLWA(PORT, (error, authCode) => {
                 if (error) {

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -119,7 +119,7 @@ module.exports.SKILL = {
 
 module.exports.CONFIGURATION = {
     JSON_DISPLAY_INDENT: 2,
-    OPN_BROWSER_DELAY: 1000,
+    OPEN_BROWSER_DELAY: 1000,
     RETRY: {
         GET_PACKAGE_IMPORT_STATUS: {
             MAX_RETRY: 50,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jsonfile": "^2.4.0",
     "listr": "^0.14.3",
     "module-alias": "^2.1.0",
-    "opn": "^4.0.2",
+    "open": "^7.0.3",
     "ora": "^3.4.0",
     "portscanner": "^2.1.1",
     "pretty-bytes": "^5.1.0",

--- a/test/unit/commands/configure/aws-profile-setup-helper-test.js
+++ b/test/unit/commands/configure/aws-profile-setup-helper-test.js
@@ -196,9 +196,9 @@ describe('Command: Configure - AWS profile setup helper test', () => {
         it('| returns valid awsProfile ', (done) => {
             // setup
             const DEFAULT_AWS_PROFILE = 'ask_cli_default';
-            const opnStub = sinon.stub();
+            const openStub = sinon.stub();
             const proxyHelper = proxyquire('@src/commands/configure/aws-profile-setup-helper', {
-                opn: opnStub
+                open: openStub
             });
             const infoStub = sinon.stub();
             sinon.stub(Messenger, 'getInstance').returns({

--- a/test/unit/commands/configure/helper-test.js
+++ b/test/unit/commands/configure/helper-test.js
@@ -28,18 +28,21 @@ describe('Command: Configure - helper test', () => {
     };
     let setTokenStub;
     let infoStub;
+    let warnStub;
     let setAwsProfileStub;
     let writeStub;
     let setVendorIdStub;
     describe('# test initiateAskProfileSetup', () => {
         beforeEach(() => {
             infoStub = sinon.stub();
+            warnStub = sinon.stub();
             setAwsProfileStub = sinon.stub();
             setVendorIdStub = sinon.stub();
             writeStub = sinon.stub();
             setTokenStub = sinon.stub();
             sinon.stub(Messenger, 'getInstance').returns({
-                info: infoStub
+                info: infoStub,
+                warn: warnStub
             });
             sinon.stub(AppConfig, 'getInstance').returns({
                 write: writeStub,
@@ -59,6 +62,7 @@ describe('Command: Configure - helper test', () => {
             // call
             helper.initiateAskProfileSetup(TEST_CONFIG, (error, askProfile) => {
                 // verify
+                expect(warnStub.args[0][0]).eq(messages.LWA_TOKEN_SHARE_WARN_MESSAGE);
                 expect(error).eq(TEST_ERROR_MESSAGE);
                 expect(askProfile).eq(undefined);
                 done();
@@ -73,6 +77,7 @@ describe('Command: Configure - helper test', () => {
             // call
             helper.initiateAskProfileSetup(TEST_CONFIG, (error, askProfile) => {
                 // verify
+                expect(warnStub.args[0][0]).eq(messages.LWA_TOKEN_SHARE_WARN_MESSAGE);
                 expect(setTokenStub.args[0][0]).eq(TEST_PROFILE);
                 expect(setTokenStub.args[0][1]).to.deep.eq(TEST_ACCESS_TOKEN);
                 expect(infoStub.args[0][0]).eq(`ASK Profile "${TEST_PROFILE}" was successfully created. The details are recorded in ask-cli config file (.ask/cli_config) located at your **HOME** folder.`);
@@ -91,6 +96,7 @@ describe('Command: Configure - helper test', () => {
             // call
             helper.initiateAskProfileSetup(TEST_CONFIG, (error, askProfile) => {
                 // verify
+                expect(warnStub.args[0][0]).eq(messages.LWA_TOKEN_SHARE_WARN_MESSAGE);
                 expect(setVendorIdStub.args[0][0]).eq(TEST_PROFILE);
                 expect(setVendorIdStub.args[0][1]).to.deep.eq(TEST_VENDOR_ID);
                 expect(infoStub.args[0][0]).eq(`ASK Profile "${TEST_PROFILE}" was successfully created. The details are recorded in ask-cli config file (.ask/cli_config) located at your **HOME** folder.`);
@@ -110,11 +116,13 @@ describe('Command: Configure - helper test', () => {
             // call
             helper.initiateAskProfileSetup(TEST_CONFIG, (error, askProfile) => {
                 // verify
+                expect(warnStub.args[0][0]).eq(messages.LWA_TOKEN_SHARE_WARN_MESSAGE);
                 expect(setVendorIdStub.args[0][0]).eq(TEST_PROFILE);
                 expect(setVendorIdStub.args[0][1]).to.deep.eq(TEST_VENDOR_ID);
                 expect(infoStub.args[0][0]).eq(`ASK Profile "${TEST_PROFILE}" was successfully created. The details are recorded in ask-cli config file (.ask/cli_config) located at your **HOME** folder.`);
                 expect(infoStub.args[1][0]).eq(`Vendor ID set as ${TEST_VENDOR_ID}.\n`);
                 expect(infoStub.args[2][0]).eq(messages.AWS_CONFIGURATION_MESSAGE);
+                expect(warnStub.args[1][0]).eq(messages.AWS_SECRET_ACCESS_KEY_AND_ID_SHARE_WARN_MESSAGE);
                 expect(setAwsProfileStub.args[0][0]).eq(TEST_PROFILE);
                 expect(setAwsProfileStub.args[0][1]).to.deep.eq(undefined);
                 expect(error).eq(null);
@@ -132,11 +140,13 @@ describe('Command: Configure - helper test', () => {
             // call
             helper.initiateAskProfileSetup(TEST_CONFIG, (error, askProfile) => {
                 // verify
+                expect(warnStub.args[0][0]).eq(messages.LWA_TOKEN_SHARE_WARN_MESSAGE);
                 expect(setVendorIdStub.args[0][0]).eq(TEST_PROFILE);
                 expect(setVendorIdStub.args[0][1]).to.deep.eq(TEST_VENDOR_ID);
                 expect(infoStub.args[0][0]).eq(`ASK Profile "${TEST_PROFILE}" was successfully created. The details are recorded in ask-cli config file (.ask/cli_config) located at your **HOME** folder.`);
                 expect(infoStub.args[1][0]).eq(`Vendor ID set as ${TEST_VENDOR_ID}.\n`);
                 expect(infoStub.args[2][0]).eq(messages.AWS_CONFIGURATION_MESSAGE);
+                expect(warnStub.args[1][0]).eq(messages.AWS_SECRET_ACCESS_KEY_AND_ID_SHARE_WARN_MESSAGE);
                 expect(infoStub.args[3][0]).eq(`AWS profile "${TEST_AWS_PROFILE}" was successfully associated with your ASK profile "${TEST_PROFILE}".\n`);
                 expect(setAwsProfileStub.args[0][0]).eq(TEST_PROFILE);
                 expect(setAwsProfileStub.args[0][1]).to.deep.eq(TEST_AWS_PROFILE);

--- a/test/unit/commands/v2new/hosted-skill-helper-test.js
+++ b/test/unit/commands/v2new/hosted-skill-helper-test.js
@@ -44,9 +44,9 @@ describe('Commands new test - hosted skill helper test', () => {
             sinon.stub(Messenger, 'getInstance').returns({
                 info: infoStub
             });
-            const opnStub = sinon.stub();
+            const openStub = sinon.stub();
             proxyHelper = proxyquire('@src/commands/v2new/hosted-skill-helper', {
-                opn: opnStub
+                open: openStub
             });
             endStub = sinon.stub();
             response = {

--- a/test/unit/controller/authorization-controller/index-test.js
+++ b/test/unit/controller/authorization-controller/index-test.js
@@ -292,7 +292,7 @@ describe('Controller test - Authorization controller test', () => {
     });
 
     describe('# test getTokensByListeningOnPort', () => {
-        let proxyHelper, opnStub, infoStub;
+        let proxyHelper, openStub, infoStub;
 
         beforeEach(() => {
             sinon.stub(httpClient, 'request');
@@ -301,9 +301,9 @@ describe('Controller test - Authorization controller test', () => {
             sinon.stub(Messenger, 'getInstance').returns({
                 info: infoStub
             });
-            opnStub = sinon.stub();
+            openStub = sinon.stub();
             proxyHelper = proxyquire('@src/controllers/authorization-controller', {
-                opn: opnStub
+                open: openStub
             });
         });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add warn messaging to inform user to keep authorization code, access tokens and AWS secret key and access key id safe.
* Update "opn" to "open" package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
