### PR TITLE
feat: enable interaction after record args validation failure, option to

### DIFF
--- a/docs/concepts/Dialog-Command.md
+++ b/docs/concepts/Dialog-Command.md
@@ -56,7 +56,7 @@ User  > .quit
 ```
 #### Special sub-commands:
 
-**.record**: To record the list of utterances so far in a JSON file. User can continue to interact with the skill once the replay file has been created.
+**.record**: To record the list of utterances so far in a JSON file. User can continue to interact with the skill once the replay file has been created. This command provides user an option  `--append-quit`, which the user can append to record command, to add `.quit` to list of utterances before creation of replay file. Format: `.record <fileName>`  or `.record <fileName> --append-quit`.
 
 **.quit**: Exits the Interactive mode.
 

--- a/lib/commands/dialog/index.js
+++ b/lib/commands/dialog/index.js
@@ -3,6 +3,7 @@ const path = require('path');
 const SmapiClient = require('@src/clients/smapi-client');
 const { AbstractCommand } = require('@src/commands/abstract-command');
 const optionModel = require('@src/commands/option-model');
+const CliError = require('@src/exceptions/cli-error');
 const DialogReplayFile = require('@src/model/dialog-replay-file');
 const ResourcesConfig = require('@src/model/resources-config');
 const CONSTANTS = require('@src/utils/constants');
@@ -89,7 +90,7 @@ class DialogCommand extends AbstractCommand {
                     new ResourcesConfig(path.join(process.cwd(), CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG));
                     skillId = ResourcesConfig.getInstance().getSkillId(profile);
                 } catch (err) {
-                    throw 'Failed to read project resource file.';
+                    throw new CliError('Failed to read project resource file. Please run the command within a ask-cli project.');
                 }
                 if (!stringUtils.isNonBlankString(skillId)) {
                     throw `Failed to obtain skill-id from project resource file ${CONSTANTS.FILE_PATH.ASK_RESOURCES_JSON_CONFIG}`;

--- a/lib/commands/dialog/replay-mode.js
+++ b/lib/commands/dialog/replay-mode.js
@@ -54,6 +54,7 @@ module.exports = class ReplayMode extends DialogController {
                 replayReplView.close();
                 this.config.header = 'Switching to interactive dialog.\n'
                 + 'To automatically quit after replay, append \'.quit\' to the userInput of your replay file.';
+                this.config.session = false;
                 const interactiveReplView = new InteractiveMode(this.config);
                 interactiveReplView.start(callback);
             }

--- a/lib/controllers/dialog-controller/index.js
+++ b/lib/controllers/dialog-controller/index.js
@@ -8,6 +8,7 @@ const Messenger = require('@src/view/messenger');
 const responseParser = require('@src/controllers/dialog-controller/simulation-response-parser');
 const SkillSimulationController = require('@src/controllers/skill-simulation-controller');
 
+const RECORD_FORMAT = 'Please use the format: ".record <fileName>" or ".record <fileName> --append-quit"';
 module.exports = class DialogController extends SkillSimulationController {
     /**
      * Constructor for DialogModeController.
@@ -15,7 +16,7 @@ module.exports = class DialogController extends SkillSimulationController {
      */
     constructor(configuration) {
         super(configuration);
-        this.newSession = true;
+        this.newSession = configuration.newSession === false ? configuration.newSession : true;
         this.utteranceCache = [];
     }
 
@@ -67,22 +68,52 @@ module.exports = class DialogController extends SkillSimulationController {
      * @param {Function} callback
      */
     setupSpecialCommands(dialogReplView, callback) {
-        dialogReplView.registerRecordCommand((filePath) => {
-            if (!stringUtils.isNonBlankString(filePath)) {
-                return callback('A file name has not been specified');
+        dialogReplView.registerRecordCommand((recordArgs) => {
+            const recordArgsList = recordArgs.trim().split(' ');
+            if (!stringUtils.isNonBlankString(recordArgs) || recordArgsList.length > 2) {
+                return Messenger.getInstance().warn(`Incorrect format. ${RECORD_FORMAT}`);
             }
-            const JSON_FILE_EXTENSION = '.json';
-            if (path.extname(filePath).toLowerCase() !== JSON_FILE_EXTENSION) {
-                return callback(`File should be of type '${JSON_FILE_EXTENSION}'`);
+            const { filePath, shouldAppendQuit } = this._validateRecordCommandInput(recordArgsList, RECORD_FORMAT);
+            const utteranceCacheCopy = [...this.utteranceCache];
+            if (shouldAppendQuit) {
+                utteranceCacheCopy.push('.quit');
             }
-            try {
-                this.createReplayFile(filePath);
-                Messenger.getInstance().info(`Created replay file at ${filePath}`);
-            } catch (err) {
-                return callback(err);
+            if (filePath) {
+                try {
+                    this.createReplayFile(filePath, utteranceCacheCopy);
+                    Messenger.getInstance().info(`Created replay file at ${filePath}`
+                        + `${shouldAppendQuit ? ' (appended ".quit" to list of utterances).' : ''}`);
+                } catch (replayFileCreationError) {
+                    return callback(replayFileCreationError);
+                }
             }
         });
         dialogReplView.registerQuitCommand(() => {});
+    }
+
+    /**
+     * Validate record command arguments.
+     * @param {Array} recordArgsList
+     * @param {String} recordCommandFormat
+     */
+    _validateRecordCommandInput(recordArgsList) {
+        const filePath = recordArgsList[0];
+        const appendQuitArgument = recordArgsList[1];
+        let shouldAppendQuit = false;
+        const JSON_FILE_EXTENSION = '.json';
+
+        if (path.extname(filePath).toLowerCase() !== JSON_FILE_EXTENSION) {
+            Messenger.getInstance().warn(`File should be of type '${JSON_FILE_EXTENSION}'`);
+            return {};
+        }
+        if (stringUtils.isNonBlankString(appendQuitArgument)) {
+            if (appendQuitArgument !== '--append-quit') {
+                Messenger.getInstance().warn(`Unable to validate arguments: "${appendQuitArgument}". ${RECORD_FORMAT}`);
+                return {};
+            }
+            shouldAppendQuit = true;
+        }
+        return { filePath, shouldAppendQuit };
     }
 
     /**
@@ -136,13 +167,13 @@ module.exports = class DialogController extends SkillSimulationController {
      * Function to create replay file.
      * @param {String} filename name of file to save replay JSON.
      */
-    createReplayFile(filename) {
+    createReplayFile(filename, utterances) {
         if (stringUtils.isNonBlankString(filename)) {
             const content = {
                 skillId: this.skillId,
                 locale: this.locale,
                 type: 'text',
-                userInput: this.utteranceCache
+                userInput: utterances
             };
             fs.outputJSONSync(filename, content);
         }

--- a/test/unit/commands/dialog/index-test.js
+++ b/test/unit/commands/dialog/index-test.js
@@ -234,7 +234,7 @@ describe('Commands Dialog test - command class test', () => {
                 // call
                 instance.handle(TEST_CMD_WITH_VALUES, (err) => {
                     // verify
-                    expect(err).equal('Failed to read project resource file.');
+                    expect(err.message).equal('Failed to read project resource file. Please run the command within a ask-cli project.');
                     done();
                 });
             });


### PR DESCRIPTION
append quit to replay file, update messaging, continue session after recording

*Issue #, if available:*

*Description of changes:*
* enable interaction after record args validation failure.
* option to append .quit to replay file.
* Update messaging when command is executed outside cli project.
* session persistence once record is done.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
