### PR TITLE
fix: update messaging in dialog, configure and new commands

### DIFF
--- a/lib/commands/dialog/interactive-mode.js
+++ b/lib/commands/dialog/interactive-mode.js
@@ -3,12 +3,14 @@ const chalk = require('chalk');
 const DialogReplView = require('@src/view/dialog-repl-view');
 const DialogController = require('@src/controllers/dialog-controller');
 
+const SPECIAL_COMMANDS_HEADER = 'Use ".record <fileName>" or ".record <fileName> --append-quit" to save list of utterances to a file.\n'
++ 'You can exit the interactive mode by entering ".quit" or "ctrl + c".';
 module.exports = class InteractiveMode extends DialogController {
     constructor(config) {
         super(config);
         this.header = config.header || 'Welcome to ASK Dialog\n'
         + 'In interactive mode, type your utterance text onto the console and hit enter\n'
-        + 'Alexa will then evaluate your input and give a response!';
+        + 'Alexa will then evaluate your input and give a response!\n';
     }
 
     start(callback) {
@@ -16,7 +18,7 @@ module.exports = class InteractiveMode extends DialogController {
         try {
             interactiveReplView = new DialogReplView({
                 prompt: chalk.yellow.bold('User  > '),
-                header: this.header,
+                header: this.header + SPECIAL_COMMANDS_HEADER,
                 footer: 'Goodbye!',
                 evalFunc: (input, replCallback) => {
                     this.evaluateUtterance(input, interactiveReplView, replCallback);

--- a/lib/commands/dialog/replay-mode.js
+++ b/lib/commands/dialog/replay-mode.js
@@ -53,7 +53,7 @@ module.exports = class ReplayMode extends DialogController {
                 replayReplView.clearSpecialCommands();
                 replayReplView.close();
                 this.config.header = 'Switching to interactive dialog.\n'
-                + 'To automatically quit after replay, append \'.quit\' to the userInput of your replay file.';
+                + 'To automatically quit after replay, append \'.quit\' to the userInput of your replay file.\n';
                 this.config.session = false;
                 const interactiveReplView = new InteractiveMode(this.config);
                 interactiveReplView.start(callback);

--- a/lib/commands/option-model.json
+++ b/lib/commands/option-model.json
@@ -1,7 +1,7 @@
 {
   "profile": {
     "name": "profile",
-    "description": "ask cli profile",
+    "description": "ask cli profile. A profile is a container that stores sets of credentials (access tokens, vendor id and corresponding aws profile)",
     "alias": "p",
     "stringInput": "REQUIRED"
   },
@@ -38,7 +38,7 @@
       "type": "REGEX",
       "regex": "^[./]?[\\w\\-. /]+\\.(json)"
     }]
-  },  
+  },
   "hosted-skill-id": {
     "name": "hosted-skill-id",
     "description": "skill-id for the Alexa hosted skill",

--- a/lib/commands/v2new/index.js
+++ b/lib/commands/v2new/index.js
@@ -11,6 +11,9 @@ const helper = require('./helper');
 const hostedHelper = require('./hosted-skill-helper');
 const wizardHelper = require('./wizard-helper');
 
+const GIT_USAGE_HOSTED_SKILL_DOCUMENTATION = 'https://developer.amazon.com/en-US/docs/alexa/'
+    + 'hosted-skills/build-a-skill-end-to-end-using-an-alexa-hosted-skill.html#askcli';
+
 class NewCommand extends AbstractCommand {
     name() {
         return 'new';
@@ -79,6 +82,8 @@ function createHostedSkill(cmd, profile, vendorId, userInput, callback) {
                 return callback(createErr);
             }
             Messenger.getInstance().info(`Hosted skill provisioning finished. Skill-Id: ${skillId}`);
+            Messenger.getInstance().info(`Please follow the instructions at ${GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
+                + ' to learn more about the usage of "git" for Hosted skill.');
             ResourcesConfig.getInstance().write();
             callback();
         });

--- a/test/unit/commands/dialog/replay-mode-test.js
+++ b/test/unit/commands/dialog/replay-mode-test.js
@@ -94,7 +94,7 @@ describe('# Command: Dialog - Replay Mode test ', () => {
             expect(clearSpecialCommandsStub.calledOnce).equal(true);
             expect(replViewCloseStub.calledOnce).equal(true);
             expect(config.header).equal('Switching to interactive dialog.\n'
-            + 'To automatically quit after replay, append \'.quit\' to the userInput of your replay file.');
+            + 'To automatically quit after replay, append \'.quit\' to the userInput of your replay file.\n');
             expect(interactiveStartStub.calledOnce).equal(true);
         });
     });

--- a/test/unit/commands/v2new/index-test.js
+++ b/test/unit/commands/v2new/index-test.js
@@ -172,6 +172,8 @@ describe('Commands new test - command class test', () => {
                 const TEST_USER_INPUT = {
                     deploymentType: TEST_HOSTED_DEPLOYMENT
                 };
+                const GIT_USAGE_HOSTED_SKILL_DOCUMENTATION = 'https://developer.amazon.com/en-US/docs/alexa/'
+                    + 'hosted-skills/build-a-skill-end-to-end-using-an-alexa-hosted-skill.html#askcli';
                 wizardHelper.collectUserCreationProjectInfo.callsArgWith(1, null, TEST_USER_INPUT);
                 hostedHelper.validateUserQualification.callsArgWith(2, null);
                 hostedHelper.createHostedSkill.callsArgWith(3, null, TEST_SKILL_ID);
@@ -181,6 +183,8 @@ describe('Commands new test - command class test', () => {
                     expect(err).equal(undefined);
                     expect(infoStub.args[0][0]).equal('Please follow the wizard to start your Alexa skill project ->');
                     expect(infoStub.args[1][0]).equal(`Hosted skill provisioning finished. Skill-Id: ${TEST_SKILL_ID}`);
+                    expect(infoStub.args[2][0]).equal(`Please follow the instructions at ${GIT_USAGE_HOSTED_SKILL_DOCUMENTATION}`
+                        + ' to learn more about the usage of "git" for Hosted skill.');
                     expect(warnStub.callCount).equal(0);
                     done();
                 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update headers in dialog command to display the usage of `.record` and `.quit` sub commands.
* Provide messaging for the usage of git for Hosted skill after clone finishes.
* Provide better description for ASK CLI profile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
